### PR TITLE
Relax permissions on directories/files needed for running cron

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,11 @@ ONBUILD RUN /builder-wrapper
 ENV PORT 3000
 EXPOSE 3000
 
+# Relax permissions on files/directories used by cron to allow for easier cron setup.
+RUN chmod 777 /var/log
+RUN chmod 777 /var/run
+RUN chmod 0777 /var/spool/cron
+RUN chmod 1777 /var/spool/cron/crontabs
+RUN chmod go+s /usr/bin/crontab
+
 ENTRYPOINT ["/exec-wrapper"]


### PR DESCRIPTION
Getting crons running under autobuild is tricky because its `/exec-wrapper` entrypoint executes as an image-specific non-root user which means that the crontab is usually installed by that non-root user. People who run crons from the autobuild image often end up making all of the permission changes in this patch in their derived image, so let's run them in the autobuild image build to make cron setup a little easier.