### PR TITLE
Make cron execute as root when run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,6 @@ RUN chmod 777 /var/run
 RUN chmod 0777 /var/spool/cron
 RUN chmod 1777 /var/spool/cron/crontabs
 RUN chmod go+s /usr/bin/crontab
+RUN chmod u+s /usr/sbin/cron
 
 ENTRYPOINT ["/exec-wrapper"]


### PR DESCRIPTION
Anything less will throw `seteuid: Operation not permitted` when the image-specific user attempts to run cron (e.g., `/exec-wrapper cron`).